### PR TITLE
Incorrect duration metadata shown for converted audio file 

### DIFF
--- a/lib/providers/saavn.js
+++ b/lib/providers/saavn.js
@@ -27,6 +27,7 @@ module.exports = class Saavn extends Provider {
               image: track.image_url,
               composer: track.music,
               artist: track.singers,
+              time: track.duration,
               year: track.year
             };
           });

--- a/lib/youtube/downloader.js
+++ b/lib/youtube/downloader.js
@@ -35,6 +35,11 @@ module.exports = class YouTubeDownloader {
         this.getLength().then(lengthInSeconds => {
           const conversionProc = ffmpeg(this.mp4OutputPath);
 
+          // Fix: Incorrectly displays doubled duration metadata
+          // in the converted audio file
+          // Reference: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/387
+          conversionProc.outputOptions(['-write_xing 0']);
+
           if (lengthInSeconds) conversionProc.withDuration(lengthInSeconds);
 
           conversionProc.on('progress', (info) => {


### PR DESCRIPTION
The duration is shown **double** than the actual duration though it finishes playback in actual time.