### PR TITLE
Fix: -h and -v options stopped working

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ PrerequisitesChecker(function() {
 
   cli.enable('version');
   cli.setApp(name, version);
+  cli.parse();
 
   if (!cli.args[0]) {
     cli.error("Please provide the URL to the album/playlist of songs which you want to download.")

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/vishaltelangre/music-dl"
   },
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Download audio song playlists/albums from multiple song providers!",
   "main": "index.js",
   "author": "Vishal Telangre <the@vishaltelangre.com>",


### PR DESCRIPTION
Regression caused due to https://github.com/vishaltelangre/music-dl/pull/32.